### PR TITLE
Remove -fslp-vectorize-aggressive from Makefile.clang

### DIFF
--- a/makefiles/Makefile.clang
+++ b/makefiles/Makefile.clang
@@ -4,7 +4,7 @@ CXX=clang++
 # no FC for clang
 FC=
 flags = -O3 -fstrict-aliasing
-vecflags = -fvectorize -fslp-vectorize-aggressive
+vecflags = -fvectorize -fslp-vectorize
 novecflags = -fno-vectorize
 omp_flags=-fopenmp=libomp
 


### PR DESCRIPTION
-fslp-vectorize-aggressive has been deprecated in Clang, it is superseded by regular -fslp-vectorize.

https://reviews.llvm.org/D34846
https://reviews.llvm.org/D34926